### PR TITLE
Changing 'permanently' to 'persistently'

### DIFF
--- a/docs/manual/patterns/twitter-clone.md
+++ b/docs/manual/patterns/twitter-clone.md
@@ -33,7 +33,7 @@ The essence of a key-value store is the ability to store some data, called a _va
 
     SET foo bar
 
-Redis stores data permanently, so if I later ask "_What is the value stored in key foo?_" Redis will reply with *bar*:
+Redis stores data persistently, so if I later ask "_What is the value stored in key foo?_" Redis will reply with *bar*:
 
     GET foo => bar
 


### PR DESCRIPTION
I suggest replacing 'permanently' with 'persistently' because Redis key-values are NOT immutable. What this paragraph is describing is that the key-values persist through sessions, etc. However, since the values can be incremented and otherwise changed, I say they are not permanent/immutable.